### PR TITLE
feat!: internal embedded sqlite3 for advanced filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module memmondiff
 
 go 1.23.2
 
-require github.com/dustin/go-humanize v1.0.1 // indirect
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/justfile
+++ b/justfile
@@ -29,3 +29,6 @@ help: build
 
 pretty-print: build
     ./memmondiff --min=10000 --pretty-print ./testdata/ycsb_before ./testdata/ycsb_after
+
+run-sql-min-10000-no-new: build
+    ./memmondiff --sql="diff >= 10000 AND before <> 0" ./testdata/ycsb_before ./testdata/ycsb_after


### PR DESCRIPTION
# Use SQLite for Advanced Filtering Features

This PR introduces SQLite as an embedded database to provide advanced filtering capabilities for our CLI tool.

## Changes
- Added embedded SQLite database for dynamic query filtering
- Added `--sql` flag for custom WHERE clauses
- Migrated filtering logic to SQL queries
- Maintained existing formatting and color output

## Examples
```bash
# Filter files with diff > 1000 bytes
./program --sql "diff > 1000" before.txt after.txt

# Complex filters
./program --sql "diff > 1000 AND filename LIKE '%.go'" before.txt after.txt

# Advanced query with multiple conditions
./program --sql "diff > 1000 AND after > before * 2 AND filename NOT LIKE '%.test.go'" before.txt after.txt
```

## Testing
- [x] Basic filtering functionality
- [x] Complex SQL queries
- [x] Edge cases with invalid SQL
- [x] Performance with large datasets

## Dependencies
- Added `github.com/mattn/go-sqlite3`